### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=sreg
+version=0.1.0
+author=Venelin Petrov
+maintainer=Venelin Petrov
+sentence=Provides a useful set of higher level routines for controlling 74HC595 shift register.
+paragraph=74HC595s are widely used as IO expanders for digital signal outputs.
+category=Signal Input/Ouput
+url=https://github.com/venelinpetrov/sreg
+architectures=*
+includes=sreg.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the Arduino Library Manager index.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata